### PR TITLE
Fix an error when accessing preferences

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -67,8 +67,10 @@ function buildPrefsWidget() {
 
     cellrend.connect('accel-edited', function(rend, iter, key, mods) {
         let value = Gtk.accelerator_name(key, mods);
-
-        let [success, iter] = model.get_iter_from_string(iter);
+        
+        let success = false;
+        
+        [success, iter] = model.get_iter_from_string(iter);
 
         if (!success) {
             throw new Error("Something be broken, yo.");


### PR DESCRIPTION
problem on gnome 3.24 (dunno on older versions/other )
iter variable already declared so gnome throws an error. This way works perfectly for me.