### PR TITLE
Fix not able to launch on Gnome 3.32

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,6 +12,9 @@ const Tweener = imports.ui.tweener;
 const Utils   = imports.misc.extensionUtils.getCurrentExtension().imports.utils;
 const mySettings = Utils.getSettings();
 
+// GLib import
+const GLib = imports.gi.GLib;
+
 // Globals
 const key_bindings = {
     'key': function(){
@@ -41,9 +44,8 @@ function init(extensionMeta) {
 }
 
 function _startTilix() {
-    try {
-        Util.trySpawnCommandLine('env GDK_BACKEND=x11 tilix --quake');
-    } catch(err) {
+    let s = GLib.spawn_command_line_async('env GDK_BACKEND=x11 tilix --quake');
+    if(s == false) {
         Main.notify("Couldn't start tilix, is it installed?");
     }
 }


### PR DESCRIPTION
Hi,
This PR fixes the problem on not able to launch Tilix (even though Tilix is installed) on Gnome 3.3
2.
Seems the original way of trySpawnCommandLine() failed so a version using GLib is used.